### PR TITLE
Develop

### DIFF
--- a/TfvcBranchPolicy.CheckinPolicy.DemoUI/Form1.cs
+++ b/TfvcBranchPolicy.CheckinPolicy.DemoUI/Form1.cs
@@ -24,10 +24,11 @@ namespace TfvcBranchPolicy.CheckinPolicy.DemoUI
         private void button1_Click(object sender, EventArgs e)
         {
             List<BranchPattern> branchPatterns = new List<BranchPattern>();
-            var wpfwindow = new BranchLockPolicyEditorWindow(branchPatterns);
+            IBranchPatternsRepository repo = new BranchPatternsRepository(branchPatterns);
+            var wpfwindow = new BranchLockPolicyEditorWindow(null, repo);
             ElementHost.EnableModelessKeyboardInterop(wpfwindow);
             wpfwindow.ShowDialog();
-            branchPatterns = wpfwindow.ViewModel.GetBranchPatterns().ToList();
+            branchPatterns = repo.FindAll().ToList();
             this.Close();
         }
     }

--- a/TfvcBranchPolicy.CheckinPolicy.DemoUI/TfvcBranchPolicy.CheckinPolicy.DemoUI.csproj
+++ b/TfvcBranchPolicy.CheckinPolicy.DemoUI/TfvcBranchPolicy.CheckinPolicy.DemoUI.csproj
@@ -32,6 +32,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.TeamFoundation.VersionControl.Client, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/TfvcBranchPolicy.CheckinPolicy/Common/BranchPattern.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Common/BranchPattern.cs
@@ -21,7 +21,7 @@ namespace TfvcBranchPolicy.CheckinPolicy.Common
         [OptionalField(VersionAdded = 2)]
         private string _name;
         [OptionalField(VersionAdded = 2)]
-        public ObservableCollection<IBranchPolicy> _branchPolicies;
+        private ObservableCollection<IBranchPolicy> _branchPolicies;
 
         public string Name
         {
@@ -56,9 +56,7 @@ namespace TfvcBranchPolicy.CheckinPolicy.Common
             this.Pattern = pattern;
             this.Name = pattern;
             _branchPolicies = new ObservableCollection<IBranchPolicy>();
-            BranchPolicies.Add(new LockBranchPolicy());
-            BranchPolicies.Add(new CodeReviewBranchPolicy());
-            BranchPolicies.Add(new WorkItemBranchPolicy());
+           
         }
 
         public ObservableCollection<IBranchPolicy> BranchPolicies

--- a/TfvcBranchPolicy.CheckinPolicy/Common/BranchPatternsRepository.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Common/BranchPatternsRepository.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TfvcBranchPolicy.CheckinPolicy.Common
+{
+    public class BranchPatternsRepository: IBranchPatternsRepository
+    {
+        private readonly IEnumerable<BranchPattern> _collection;
+
+         public BranchPatternsRepository(IEnumerable<BranchPattern> collection)
+        {
+            _collection = collection;
+        }
+
+         public IEnumerable<BranchPattern> FindAll()
+         {
+             return _collection;
+         }
+
+         public IEnumerable<BranchPattern> Find(string text)
+         {
+             throw new NotImplementedException();
+         }
+
+         public void Add(BranchPattern branchPattern)
+         {
+             throw new NotImplementedException();
+         }
+
+         public void Remove(BranchPattern branchPattern)
+         {
+             throw new NotImplementedException();
+         }
+
+         public BranchPattern Get(string id)
+         {
+             throw new NotImplementedException();
+         }
+
+         public void Save(BranchPattern entity)
+         {
+             throw new NotImplementedException();
+         }
+
+         public void Delete(BranchPattern entity)
+         {
+             throw new NotImplementedException();
+         }
+    }
+}

--- a/TfvcBranchPolicy.CheckinPolicy/Common/IBranchPatternsRepository.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Common/IBranchPatternsRepository.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TfvcBranchPolicy.CheckinPolicy.Common
+{
+    public interface IBranchPatternsRepository : IRepository<BranchPattern, string>
+    {
+        IEnumerable<BranchPattern> FindAll();
+        IEnumerable<BranchPattern> Find(string text);
+
+        void Add(BranchPattern branchPattern);
+
+        void Remove(BranchPattern branchPattern);
+    }
+}

--- a/TfvcBranchPolicy.CheckinPolicy/Common/IRepository.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Common/IRepository.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TfvcBranchPolicy.CheckinPolicy.Common
+{
+    public interface IRepository<TEntity, in TKey> where TEntity : class
+    {
+        TEntity Get(TKey id);
+        void Save(TEntity entity);
+        void Delete(TEntity entity);
+    }
+}

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/Themes/CodeReviewBranchPolicy.xaml
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/Themes/CodeReviewBranchPolicy.xaml
@@ -1,11 +1,12 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:common="clr-namespace:TfvcBranchPolicy.CheckinPolicy.Common">
+    xmlns:common="clr-namespace:TfvcBranchPolicy.CheckinPolicy.Common"
+    xmlns:viewmodels="clr-namespace:TfvcBranchPolicy.CheckinPolicy.Editor.ViewModels">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/TfvcBranchPolicy.CheckinPolicy;component/Editor/Themes/Generic.xaml"/>
     </ResourceDictionary.MergedDictionaries>
-    <DataTemplate DataType="{x:Type common:CodeReviewBranchPolicy}">
+    <DataTemplate DataType="{x:Type viewmodels:CodeReviewBranchPolicyViewModel}">
         <GroupBox DockPanel.Dock="Top" Header="Code review requirements" Margin="5">
             <StackPanel>
                 <StackPanel>
@@ -20,6 +21,7 @@
                             <ComboBox Text="Team to Review" ItemsSource="{Binding TeamsToChooseFrom}" SelectedItem="{Binding SelectedTeam}" />
                         </StackPanel>
                         <CheckBox Content="Allow users to approve their own changes" IsChecked="{Binding CanApproveOwnChanges}" />
+                        <CheckBox Content="Allow merge without code review" IsChecked="{Binding CanMerge}" />
                     </StackPanel>
                     <StackPanel IsEnabled="False" Visibility="Collapsed">
                         <Label Content="To require specific reviewers for portions of your code base, specify the path and add the reviewers you want to require." />

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/Themes/CodeReviewBranchPolicy.xaml
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/Themes/CodeReviewBranchPolicy.xaml
@@ -9,15 +9,19 @@
         <GroupBox DockPanel.Dock="Top" Header="Code review requirements" Margin="5">
             <StackPanel>
                 <StackPanel>
-                    <CheckBox Content="Require a minimum number of reviewers per pull request?" IsChecked="{Binding CodeReviewRequired}" />
-                    <StackPanel Margin="5" IsEnabled="False">
+                    <CheckBox Content="Require a Code Review before checkin?" IsChecked="{Binding CodeReviewRequired}" />
+                    <StackPanel Margin="5" IsEnabled="{Binding CodeReviewRequired}">
                         <StackPanel Orientation="Horizontal">
                             <Label Content="Minimum number of reviewers" />
-                            <TextBox Text="{Binding MinimumReviewers, FallbackValue=1}" IsEnabled="False" />
+                            <TextBox Text="{Binding MinimumReviewers, FallbackValue=1}" />
+                        </StackPanel>
+                        <StackPanel Orientation="Horizontal">
+                            <Label Content="Review by: " />
+                            <ComboBox Text="Team to Review" ItemsSource="{Binding TeamsToChooseFrom}" SelectedItem="{Binding SelectedTeam}" />
                         </StackPanel>
                         <CheckBox Content="Allow users to approve their own changes" IsChecked="{Binding CanApproveOwnChanges}" />
                     </StackPanel>
-                    <StackPanel IsEnabled="False">
+                    <StackPanel IsEnabled="False" Visibility="Collapsed">
                         <Label Content="To require specific reviewers for portions of your code base, specify the path and add the reviewers you want to require." />
                         <DataGrid ItemsSource="{Binding BranchPatternReviews}">
                             <DataGrid.Columns>

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/Themes/LockBranchPolicy.xaml
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/Themes/LockBranchPolicy.xaml
@@ -1,11 +1,12 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:common="clr-namespace:TfvcBranchPolicy.CheckinPolicy.Common">
+    xmlns:common="clr-namespace:TfvcBranchPolicy.CheckinPolicy.Common"
+    xmlns:viewmodels="clr-namespace:TfvcBranchPolicy.CheckinPolicy.Editor.ViewModels">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="Generic.xaml"/>
     </ResourceDictionary.MergedDictionaries>
-    <DataTemplate DataType="{x:Type common:LockBranchPolicy}">
+    <DataTemplate DataType="{x:Type viewmodels:LockBranchPolicyViewModel}">
         <GroupBox DockPanel.Dock="Top" Header="Branch Lock requirements" Margin="5">
             <StackPanel>
                 <StackPanel Orientation="Horizontal">

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/Themes/WorkItemBranchPolicy.xaml
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/Themes/WorkItemBranchPolicy.xaml
@@ -1,11 +1,12 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:common="clr-namespace:TfvcBranchPolicy.CheckinPolicy.Common">
+    xmlns:common="clr-namespace:TfvcBranchPolicy.CheckinPolicy.Common"
+    xmlns:viewmodels="clr-namespace:TfvcBranchPolicy.CheckinPolicy.Editor.ViewModels">
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/TfvcBranchPolicy.CheckinPolicy;component/Editor/Themes/Generic.xaml"/>
     </ResourceDictionary.MergedDictionaries>
-    <DataTemplate DataType="{x:Type common:WorkItemBranchPolicy}">
+    <DataTemplate DataType="{x:Type viewmodels:WorkItemBranchPolicyViewModel}">
         <GroupBox DockPanel.Dock="Top" Header="Work item linking requirements" Margin="5">
             <StackPanel>
                 <StackPanel Orientation="Horizontal">

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/BranchPatternPolicyEditorViewModel.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/BranchPatternPolicyEditorViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.CommandWpf;
+using Microsoft.TeamFoundation.VersionControl.Client;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/BranchPatternViewModel.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/BranchPatternViewModel.cs
@@ -1,0 +1,92 @@
+﻿using GalaSoft.MvvmLight;
+using Microsoft.TeamFoundation.VersionControl.Client;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TfvcBranchPolicy.CheckinPolicy.Common;
+
+namespace TfvcBranchPolicy.CheckinPolicy.Editor.ViewModels
+{
+    public class BranchPatternViewModel :  ViewModelBase, IBranchPatternViewModel
+    {
+        private IPolicyEditArgs _rawPolicyEditArgs;
+        private BranchPattern _rawBranchPattern;
+        public ObservableCollection<IBranchPolicyViewModel> _branchPolicies;
+
+        public BranchPattern RawBranchPattern
+        {
+            get { return _rawBranchPattern; }
+        }
+
+        public string Name
+        {
+            get
+            {
+                return _rawBranchPattern.Name;
+            }
+            set
+            {
+                _rawBranchPattern.Name = value;
+                RaisePropertyChanged("Name");
+            }
+        }
+
+        public string Pattern
+        {
+            get
+            {
+                return _rawBranchPattern.Pattern;
+            }
+            set
+            {
+                if (_rawBranchPattern.Pattern == _rawBranchPattern.Name) { Name = value; }
+                _rawBranchPattern.Pattern = value;
+                RaisePropertyChanged("Pattern");
+            }
+        }
+
+        public ObservableCollection<IBranchPolicyViewModel> BranchPolicies
+        {
+            get
+            {
+                return _branchPolicies;
+            }
+        }
+
+
+        public BranchPatternViewModel(IPolicyEditArgs _policyEditArgs, BranchPattern branchPattern)
+        {
+            // TODO: Complete member initialization
+            this._rawPolicyEditArgs = _policyEditArgs;
+            this._rawBranchPattern = branchPattern;
+            this._branchPolicies = new ObservableCollection<IBranchPolicyViewModel>();
+            RefreshBranchPolicies();
+
+        }
+
+        public void RefreshBranchPolicies()
+        {
+            BranchPolicies.Clear();
+            foreach (IBranchPolicy item in _rawBranchPattern.BranchPolicies)
+            {
+                if (item is CodeReviewBranchPolicy)
+                {
+                    BranchPolicies.Add(new CodeReviewBranchPolicyViewModel(_rawPolicyEditArgs, item));
+                }
+                if (item is LockBranchPolicy)
+                {
+                    BranchPolicies.Add(new LockBranchPolicyViewModel(_rawPolicyEditArgs, item));
+                }
+                if (item is WorkItemBranchPolicy)
+                {
+                    BranchPolicies.Add(new WorkItemBranchPolicyViewModel(_rawPolicyEditArgs, item));
+                }
+                
+            }
+        }
+
+    }
+}

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/BranchPolicyViewModel.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/BranchPolicyViewModel.cs
@@ -1,0 +1,32 @@
+﻿using GalaSoft.MvvmLight;
+using Microsoft.TeamFoundation.VersionControl.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using TfvcBranchPolicy.CheckinPolicy.Common;
+
+namespace TfvcBranchPolicy.CheckinPolicy.Editor.ViewModels
+{
+   public abstract class BranchPolicyViewModel : ViewModelBase, IBranchPolicyViewModel
+    {
+        private IPolicyEditArgs _rawPolicyEditArgs;
+        private IBranchPolicy _rawBranchPolicy;
+
+        public IBranchPolicy RawBranchPolicy
+        {
+            get { return _rawBranchPolicy; }
+        }
+
+        public string Name { get { return _rawBranchPolicy.Name; } }
+
+        public BranchPolicyViewModel(IPolicyEditArgs _policyEditArgs, IBranchPolicy branchPolicy)
+        {
+            // TODO: Complete member initialization
+            this._rawPolicyEditArgs = _policyEditArgs;
+            this._rawBranchPolicy = branchPolicy;
+        }
+
+       
+    }
+}

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/CodeReviewBranchPolicyViewModel.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/CodeReviewBranchPolicyViewModel.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.TeamFoundation.VersionControl.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using TfvcBranchPolicy.CheckinPolicy.Common;
+
+namespace TfvcBranchPolicy.CheckinPolicy.Editor.ViewModels
+{
+    public class CodeReviewBranchPolicyViewModel : BranchPolicyViewModel
+    {
+
+        private CodeReviewBranchPolicy RawCodeReviewBranchPolicy
+        {
+            get
+            {
+                return ((CodeReviewBranchPolicy)RawBranchPolicy);
+            }
+        }
+
+        public Boolean CodeReviewRequired
+        {
+            get
+            {
+                return RawCodeReviewBranchPolicy.CodeReviewRequired;
+            }
+            set
+            {
+                RawCodeReviewBranchPolicy.CodeReviewRequired = value;
+                RaisePropertyChanged("CodeReviewRequired");
+            }
+        }
+
+        public int MinimumReviewers
+        {
+            get
+            {
+                return RawCodeReviewBranchPolicy.MinimumReviewers;
+            }
+            set
+            {
+                RawCodeReviewBranchPolicy.MinimumReviewers = value;
+                RaisePropertyChanged("MinimumReviewers");
+            }
+        }
+
+        public Boolean CanApproveOwnChanges
+        {
+            get
+            {
+                return RawCodeReviewBranchPolicy.CanApproveOwnChanges;
+            }
+            set
+            {
+                RawCodeReviewBranchPolicy.CanApproveOwnChanges = value;
+                RaisePropertyChanged("CanApproveOwnChanges");
+            }
+        }
+
+        public CodeReviewBranchPolicyViewModel(IPolicyEditArgs policyEditArgs, IBranchPolicy item) : base(policyEditArgs, item)
+        {
+        }
+
+
+    }
+}

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/IBranchPatternViewModel.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/IBranchPatternViewModel.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.TeamFoundation.VersionControl.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TfvcBranchPolicy.CheckinPolicy.Common;
+
+namespace TfvcBranchPolicy.CheckinPolicy.Editor.ViewModels
+{
+    public interface IBranchPatternViewModel
+    {
+       BranchPattern RawBranchPattern { get; }
+    }
+}

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/IBranchPolicyViewModel.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/IBranchPolicyViewModel.cs
@@ -2,12 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using TfvcBranchPolicy.CheckinPolicy.Common;
 
-namespace TfvcBranchPolicy.CheckinPolicy.Editor
+namespace TfvcBranchPolicy.CheckinPolicy.Editor.ViewModels
 {
-    public interface IBranchPatternPolicyEditorViewModel
+    public interface IBranchPolicyViewModel
     {
+        IBranchPolicy RawBranchPolicy { get; }
     }
 }

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/LockBranchPolicyViewModel.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/LockBranchPolicyViewModel.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.TeamFoundation.VersionControl.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using TfvcBranchPolicy.CheckinPolicy.Common;
+
+namespace TfvcBranchPolicy.CheckinPolicy.Editor.ViewModels
+{
+   public  class LockBranchPolicyViewModel : BranchPolicyViewModel
+    {
+       private LockBranchPolicy RawLockBranchPolicy
+       {
+           get
+           {
+               return ((LockBranchPolicy)RawBranchPolicy);
+           }
+       }
+
+       public string BypassString
+       {
+           get
+           {
+               return RawLockBranchPolicy.BypassString;
+           }
+           set
+           {
+               RawLockBranchPolicy.BypassString = value;
+               RaisePropertyChanged("BypassString");
+           }
+       }
+       public Boolean IsLocked
+       {
+           get
+           {
+               return RawLockBranchPolicy.IsLocked;
+           }
+           set
+           {
+               RawLockBranchPolicy.IsLocked = value;
+               RaisePropertyChanged("IsLocked");
+           }
+       }
+
+       public Boolean IsByPassEnabled
+       {
+           get
+           {
+               return RawLockBranchPolicy.IsByPassEnabled;
+           }
+           set
+           {
+               RawLockBranchPolicy.IsByPassEnabled = value;
+               RaisePropertyChanged("IsByPassEnabled");
+           }
+       }
+
+       public LockBranchPolicyViewModel(IPolicyEditArgs policyEditArgs, IBranchPolicy item)
+           : base(policyEditArgs, item)
+        {
+        }
+    }
+}

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/WorkItemBranchPolicyViewModel.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/ViewModels/WorkItemBranchPolicyViewModel.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.TeamFoundation.VersionControl.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using TfvcBranchPolicy.CheckinPolicy.Common;
+
+namespace TfvcBranchPolicy.CheckinPolicy.Editor.ViewModels
+{
+    public class WorkItemBranchPolicyViewModel : BranchPolicyViewModel
+    {
+
+        private WorkItemBranchPolicy RawWorkItemBranchPolicy
+        {
+            get
+            {
+                return ((WorkItemBranchPolicy)RawBranchPolicy);
+            }
+        }
+        public Boolean WorkItemRequired
+        {
+            get
+            {
+                return RawWorkItemBranchPolicy.WorkItemRequired;
+            }
+            set
+            {
+                RawWorkItemBranchPolicy.WorkItemRequired = value;
+                RaisePropertyChanged("WorkItemRequired");
+            }
+        }
+
+        public Boolean SelfAssigned
+        {
+            get
+            {
+                return RawWorkItemBranchPolicy.SelfAssigned;
+            }
+            set
+            {
+                RawWorkItemBranchPolicy.SelfAssigned = value;
+                RaisePropertyChanged("SelfAssigned");
+            }
+        }
+
+        public WorkItemBranchPolicyViewModel(IPolicyEditArgs policyEditArgs, IBranchPolicy item)
+           : base(policyEditArgs, item)
+        {
+        }
+
+
+       
+    }
+}

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/Views/BranchLockPolicyEditorWindow.xaml
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/Views/BranchLockPolicyEditorWindow.xaml
@@ -42,7 +42,7 @@
             </DockPanel>
         </DockPanel>
         <GridSplitter ResizeDirection="Auto" VerticalAlignment="Stretch" Width="5" />
-        <DockPanel x:Name="EditPannel" Grid.Column="1" MinWidth="225" DataContext="{Binding CurrentBranchPattern}">
+        <DockPanel x:Name="EditPannel" Grid.Column="1" MinWidth="225" DataContext="{Binding SelectedBranchPattern}">
             <Label DockPanel.Dock="Top">Branch Policies:</Label>
             <GroupBox DockPanel.Dock="Top" Header="Branch Pattern Details">
                 <Grid>

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/Views/BranchLockPolicyEditorWindow.xaml.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/Views/BranchLockPolicyEditorWindow.xaml.cs
@@ -22,10 +22,10 @@ namespace TfvcBranchPolicy.CheckinPolicy.Editor
     public partial class BranchLockPolicyEditorWindow : Window
     {
         public IBranchPatternPolicyEditorViewModel ViewModel;
-        public BranchLockPolicyEditorWindow(IEnumerable<BranchPattern> collection)
+        public BranchLockPolicyEditorWindow(IPolicyEditArgs policyEditArgs, IBranchPatternsRepository repo)
         {
             InitializeComponent();
-            ViewModel = new BranchPatternPolicyEditorViewModel(collection);
+            ViewModel = new BranchPatternPolicyEditorViewModel( policyEditArgs,repo);
             this.DataContext = ViewModel;
    
         }

--- a/TfvcBranchPolicy.CheckinPolicy/Editor/Views/BranchLockPolicyEditorWindow.xaml.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Editor/Views/BranchLockPolicyEditorWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.TeamFoundation.VersionControl.Client;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/TfvcBranchPolicy.CheckinPolicy/Policies/CodeReviewBranchPolicy.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Policies/CodeReviewBranchPolicy.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.TeamFoundation.VersionControl.Client;
+﻿using Microsoft.TeamFoundation.Client;
+using Microsoft.TeamFoundation.VersionControl.Client;
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
 using System;
 using System.Collections.Generic;
@@ -19,6 +20,8 @@ namespace TfvcBranchPolicy.CheckinPolicy.Common
         [OptionalField(VersionAdded = 3)]
         private int _minimumReviewers;
         [OptionalField(VersionAdded = 3)]
+        [NonSerialized]
+        private ObservableCollection<TeamFoundationTeam> _TeamsToChooseFrom;
         private Boolean _canApproveOwnChanges;
         [OptionalField(VersionAdded = 3)]
         private ObservableCollection<BranchPatternReview> _branchPatternReviews;

--- a/TfvcBranchPolicy.CheckinPolicy/Policies/CodeReviewBranchPolicy.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/Policies/CodeReviewBranchPolicy.cs
@@ -20,11 +20,12 @@ namespace TfvcBranchPolicy.CheckinPolicy.Common
         [OptionalField(VersionAdded = 3)]
         private int _minimumReviewers;
         [OptionalField(VersionAdded = 3)]
+        private Boolean _canApproveOwnChanges;
+        [OptionalField(VersionAdded = 3)][Obsolete]
+        private ObservableCollection<BranchPatternReview> _branchPatternReviews;
+
         [NonSerialized]
         private ObservableCollection<TeamFoundationTeam> _TeamsToChooseFrom;
-        private Boolean _canApproveOwnChanges;
-        [OptionalField(VersionAdded = 3)]
-        private ObservableCollection<BranchPatternReview> _branchPatternReviews;
 
         public string Name
         {

--- a/TfvcBranchPolicy.CheckinPolicy/TfvcBranchPolicy.CheckinPolicy.csproj
+++ b/TfvcBranchPolicy.CheckinPolicy/TfvcBranchPolicy.CheckinPolicy.csproj
@@ -80,6 +80,16 @@
     <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\BranchPatternsRepository.cs" />
+    <Compile Include="Common\IBranchPatternsRepository.cs" />
+    <Compile Include="Common\IRepository.cs" />
+    <Compile Include="Editor\ViewModels\BranchPatternViewModel.cs" />
+    <Compile Include="Editor\ViewModels\BranchPolicyViewModel.cs" />
+    <Compile Include="Editor\ViewModels\CodeReviewBranchPolicyViewModel.cs" />
+    <Compile Include="Editor\ViewModels\IBranchPatternViewModel.cs" />
+    <Compile Include="Editor\ViewModels\IBranchPolicyViewModel.cs" />
+    <Compile Include="Editor\ViewModels\LockBranchPolicyViewModel.cs" />
+    <Compile Include="Editor\ViewModels\WorkItemBranchPolicyViewModel.cs" />
     <Compile Include="TfvcBranchPolicy.cs" />
     <Compile Include="Common\BranchPatternReviewer.cs" />
     <Compile Include="Common\BranchPatternReview.cs" />

--- a/TfvcBranchPolicy.CheckinPolicy/TfvcBranchPolicy.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/TfvcBranchPolicy.cs
@@ -108,15 +108,11 @@ namespace TfvcBranchPolicy.CheckinPolicy
             bool result = false;
             try
             {
-                // no policy settings to save
-                if (branchPatterns == null)
-                {
-                    branchPatterns = new List<BranchPattern>();
-                }
-                var wpfwindow = new BranchLockPolicyEditorWindow(branchPatterns);
+                IBranchPatternsRepository repo = new BranchPatternsRepository(branchPatterns);
+                var wpfwindow = new BranchLockPolicyEditorWindow(policyEditArgs, repo);
                 ElementHost.EnableModelessKeyboardInterop(wpfwindow);
                 wpfwindow.ShowDialog();
-                branchPatterns = wpfwindow.ViewModel.GetBranchPatterns().ToList();
+                branchPatterns = repo.FindAll().ToList();
                 TellMe.Instance.TrackMetric("BranchPolicyCount", branchPatterns.Count);
                 result= true;
             }

--- a/TfvcBranchPolicy.CheckinPolicy/TfvcBranchPolicy.cs
+++ b/TfvcBranchPolicy.CheckinPolicy/TfvcBranchPolicy.cs
@@ -55,7 +55,9 @@ namespace TfvcBranchPolicy.CheckinPolicy
 
         public override void DisplayHelp(PolicyFailure failure)
         {
-            System.Diagnostics.Process.Start("http://nkdagility.com/tools/tfvc-branch-policy/");
+
+
+            System.Diagnostics.Process.Start("https://github.com/nkdAgility/TfvcBranchPolicy/wiki");
         }
 
         /// <summary>

--- a/scripts/UpdateVsixmanifest.ps1
+++ b/scripts/UpdateVsixmanifest.ps1
@@ -5,6 +5,10 @@ param([string]$PublishVersion)
 Write-Verbose "PublishVersion: $PublishVersion" -verbose
 
  Get-ChildItem Env:GITVERSION* -Verbose
+
+ $Env:GITVERSION_BUILDMETADATA = $Env:GITVERSION_NUGETVERSION.substring($Env:GITVERSION_NUGETVERSION.Length-4)
+ $PublishVersion = "$Env:GITVERSION_MAJORMINORPATCH.$Env:GITVERSION_BUILDMETADATA"
+
 	
 # Regular expression pattern to find the version in the build number 
 # and then apply it to the assemblies

--- a/scripts/UpdateVsixmanifest.ps1
+++ b/scripts/UpdateVsixmanifest.ps1
@@ -4,11 +4,7 @@ param([string]$PublishVersion)
 
 Write-Verbose "PublishVersion: $PublishVersion" -verbose
 
-Write-Verbose "Major: $Env:GITVERSION_Major" -verbose
-Write-Verbose "Minor: $Env:GITVERSION_Minor" -verbose
-Write-Verbose "Patch: $Env:GITVERSION_Patch" -verbose
-Write-Verbose "MajorMinorPatch: $Env:GITVERSION_MajorMinorPatch" -verbose
-Write-Verbose "BuildMetaData: $Env:GITVERSION_BuildMetaData" -verbose
+ Get-ChildItem Env:GITVERSION* -Verbose
 	
 # Regular expression pattern to find the version in the build number 
 # and then apply it to the assemblies

--- a/scripts/UpdateVsixmanifest.ps1
+++ b/scripts/UpdateVsixmanifest.ps1
@@ -4,6 +4,11 @@ param([string]$PublishVersion)
 
 Write-Verbose "PublishVersion: $PublishVersion" -verbose
 
+Write-Verbose "Major: $Env:GITVERSION_Major" -verbose
+Write-Verbose "Minor: $Env:GITVERSION_Minor" -verbose
+Write-Verbose "Patch: $Env:GITVERSION_Patch" -verbose
+Write-Verbose "MajorMinorPatch: $Env:GITVERSION_MajorMinorPatch" -verbose
+Write-Verbose "BuildMetaData: $Env:GITVERSION_BuildMetaData" -verbose
 	
 # Regular expression pattern to find the version in the build number 
 # and then apply it to the assemblies


### PR DESCRIPTION
Moving all of my code over to VewModels with a repository. We needed to refactor to be able to pass the TeamProject object down the line without having to compromise the binary data. 

We can now remove the ObservableObject inheritance from all of the binary classes. Will need to leave the ObservableCollection as I am unsure how that will impact on the rehydration of data.
